### PR TITLE
cljc and cljs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pom.xml.asc
 *.swp
 /.lein-*
 /.nrepl-port
-doc/index.html
+doc/
 \#*\#
 *~
 .\#*

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,8 @@ of your sources and the language:
 
 [source,clojure]
 ----
-:codeina {:sources ["src"]}
+:codeina {:sources ["src"]
+         :reader :clojurescript}
 ----
 
 And run the `doc` lein subcommand:

--- a/src/codeina/core.clj
+++ b/src/codeina/core.clj
@@ -26,13 +26,12 @@
          (remove (comp empty? :publics)))))
 
 (defn- merge-namespaces [namespaces]
-  (for [[name namespaces] (group-by :name namespaces)]
-    (assoc (first namespaces) :publics (mapcat :publics namespaces))))
+  (for [[name nss] (group-by :name namespaces)]
+    (assoc (first nss) :publics (mapcat :publics nss))))
 
 (defn- cljs-read-namespaces
   [& paths]
   (let [reader (resolve-sym 'codeina.reader.clojurescript/read-namespaces)]
-    (println 2222 (apply reader paths))
     (merge-namespaces
      (concat (apply reader paths)
              (apply read-macro-namespaces paths)))))
@@ -76,7 +75,7 @@
          writer-fn (get-writer options)
          reader-fn (get-reader options)
          root (:root options)
-         sources (:sources options)
+         sources (seq (set (:sources options))) ;; Avoid reading twice
          include (:include options)
          exclude (:exclude options)
          namespaces (->> (apply reader-fn sources)


### PR DESCRIPTION
Hi,

Thanks for all the work and the great design!

The library doesn't properly work with newer versions of ClojureScript since it is [tied](https://github.com/funcool/codeina/blob/master/src/codeina/reader/clojurescript.clj#L65) to the [`cljs.analyzer`s'](https://github.com/clojure/clojurescript/blob/master/src/main/clojure/cljs/analyzer.cljc#L2756) internals which change very often.

This is going to be a fairly invasive PR. It is not ready, not polished, and not tested but now that I now that it will work, I wanted to check some things with you before proceeding:
- Is this ok? :) It might be too invasive to change how `codeina.reader.clojurescript` works. So far I just adapted the code to use almost the same `cljs.analyzer` internals but I'm planning to use `cljs.analyzer.api` to avoid breakage in the future.
- How do you want to handle differences between a var that belongs in a `cljc` and was read both from `clj` and from `cljs`? Take the following contrived but possible example, where both the `:docs` and the `:arglists` differ:

``` clj
(defn now
   #?(:clj "Returns millis from the OS, or from Java"
      :cljs "Returns millis from the Browser")
  #@?(:clj [([] (System/currentTimeMillis)
            ([java?] (if java?
                       (.getTime (java.util.Date.))
                       (now))]
      :cljs [([] (.valueOf (js/Date.)))]))
```

There are many strategies to resolve the differences, the one adopted so far is to [pick one](https://github.com/bensu/codeina/blob/cljc/src/codeina/core.clj#L36) :) You might want to display both docstrings in the html or one, I don't know.
- Related to the previous one, with the introduction of reader conditionals, codebases can now be bilingual, so the `:reader :clojurescript` option is not enought. Want might want both clj and cljs docs generated. I won't try to that in this PR, but I thought it was worth mentioning.

Thanks again

Sebastian
