### PR TITLE
Bumped up README version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ Include the following plugin in your project.clj file or your global profile:
 
 [source,clojure]
 ----
-:plugins [[funcool/codeina "0.4.0"
+:plugins [[funcool/codeina "0.5.0"
            :exclusions [org.clojure/clojure]]]
 ----
 


### PR DESCRIPTION
The most recent version is 0.5.0, but the README example still shows 0.4.0